### PR TITLE
ci: tox-lsr 3.4.0 - fix py27 tests; move other checks to py310

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
 
       - name: Convert role to collection format
         run: |

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
-extends: default
 ignore: |
   /.tox/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,5 +66,5 @@ sudo_sudoers_files:
           - ALL
     include_directories:
       - /etc/sudoers.d
-    # include_files: []
-    # aliases: []
+  # include_files: []
+  # aliases: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
     path: "{{ item }}"
     owner: root
     group: root
-    mode: 0750
+    mode: "0750"
     state: directory
   with_items: "{{ sudo_include_dirs }}"
   when: sudo_include_dirs | length > 0
@@ -32,7 +32,7 @@
     dest: "{{ item.path }}"
     owner: root
     group: root
-    mode: 0440
+    mode: "0440"
     validate: "{{ sudo_visudo_path }} -cf %s"
   with_items: "{{ sudo_sudoers_files }}"
   loop_control:
@@ -45,7 +45,7 @@
     dest: "{{ item.path }}"
     owner: root
     group: root
-    mode: 0440
+    mode: "0440"
     validate: "{{ sudo_visudo_path }} -cf %s"
   with_items: "{{ sudo_sudoers_files }}"
   loop_control:

--- a/tests/tests_large_configuration.yml
+++ b/tests/tests_large_configuration.yml
@@ -159,7 +159,7 @@
             dest: "{{ __sudo_tmpdir.path }}/sudoers"
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Backup sudoers.d
@@ -168,7 +168,7 @@
             dest: "{{ __sudo_tmpdir.path }}/sudoers.d"
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Get stat of {{ ok_path }}
@@ -204,7 +204,7 @@
             dest: /etc/sudoers
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Restore sudoers.d
@@ -213,7 +213,7 @@
             dest: /etc/sudoers.d
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Clean up temp directory

--- a/tests/tests_multiple_sudoers.yml
+++ b/tests/tests_multiple_sudoers.yml
@@ -111,7 +111,7 @@
             dest: "{{ __sudo_tmpdir.path }}/sudoers"
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Backup sudoers.d
@@ -120,7 +120,7 @@
             dest: "{{ __sudo_tmpdir.path }}/sudoers.d"
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Get stat of {{ ok_path }}
@@ -156,7 +156,7 @@
             dest: /etc/sudoers
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Restore sudoers.d
@@ -165,7 +165,7 @@
             dest: /etc/sudoers.d
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Clean up temp directory

--- a/tests/tests_role_applied.yml
+++ b/tests/tests_role_applied.yml
@@ -24,7 +24,7 @@
             dest: "{{ __sudo_tmpdir.path }}/sudoers"
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Backup sudoers.d
@@ -33,7 +33,7 @@
             dest: "{{ __sudo_tmpdir.path }}/sudoers.d"
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Check sudoers
@@ -48,7 +48,7 @@
             dest: /etc/sudoers
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Restore sudoers.d
@@ -57,7 +57,7 @@
             dest: /etc/sudoers.d
             owner: root
             group: root
-            mode: 0644
+            mode: "0644"
             remote_src: true
 
         - name: Clean up temp directory


### PR DESCRIPTION
The latest version of virtualenv does not support creating
python 2.7 virtualenvs.  Change our CI tests to restrict the version
of virtualenv<20.22.0 and tox<4.15 for py27 environments

Move pylint, flake8, and black checks to the py310 environment
which is currently supported by ansible-core 2.17 and its related
checkers such as ansible-lint and ansible-test

pylint now uses ansible-core 2.17 and restricts the version of
pylint to 3.1.0 which is the version used by ansible-test 2.17

Remove `extends: default` for .yamllint.yml.  The latest version
of ansible-lint will automatically incorporate local yamllint
settings unless there is an `extends:`.

The above changes require some fixes to the role code.

For more information, see
https://github.com/linux-system-roles/tox-lsr/pull/168
and
https://github.com/linux-system-roles/tox-lsr/pull/170

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
