### PR TITLE
ci: Handle reboot for transactional update systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Default: `/usr/bin/visudo`
 
 Type: `string`
 
+### sudo_transactional_update_reboot_ok
+
+This variable is used to handle reboots required by transactional updates.
+If a transactional update requires a reboot, the role will proceed with the
+reboot if `sudo_transactional_update_reboot_ok` is set to `true`. If set
+to `false`, the role will notify the user that a reboot is required, allowing
+for custom handling of the reboot requirement. If this variable is not set,
+the role will fail to ensure the reboot requirement is not overlooked.
+
+Default: `null`
+Type: `bool`
+
 ### sudo_sudoers_files
 
 A list that defines sudoers configurations.
@@ -414,8 +426,8 @@ sudo_sudoers_files:
                     - /usr/bin/ping
               user_alias:
                 - name: PINGERS
-                users:
-                  - username
+                  users:
+                    - username
           - path: /etc/sudoers.d/pingers
             user_specifications:
             - type: user

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@ sudo_remove_unauthorized_included_files: false
 
 sudo_visudo_path: /usr/sbin/visudo
 
+sudo_transactional_update_reboot_ok: null
+
 sudo_sudoers_files:
   - path: /etc/sudoers
     defaults:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,30 @@
     state: present
     use: "{{ (__sudo_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+  register: sudo_package_result
+
+- name: Handle reboot for transactional update systems
+  when:
+    - __sudo_is_transactional | d(false)
+    - sudo_package_result is changed
+  block:
+    - name: Notify user that reboot is needed to apply changes
+      debug:
+        msg: >
+          Reboot required to apply changes due to transactional updates.
+
+    - name: Reboot transactional update systems
+      reboot:
+        msg: Rebooting the system to apply transactional update changes.
+      when: sudo_transactional_update_reboot_ok | bool
+
+    - name: Fail if reboot is needed and not set
+      fail:
+        msg: >
+          Reboot is required but not allowed. Please set
+          'sudo_transactional_update_reboot_ok' to proceed.
+      when:
+        - sudo_transactional_update_reboot_ok is none
 
 - name: Set include directories variable
   set_fact:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -17,6 +17,18 @@
       set_fact:
         __sudo_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is transactional update and set flag
+  when: not __sudo_is_transactional is defined
+  block:
+    - name: Check if transactional-update exists in /sbin
+      stat:
+        path: /sbin/transactional-update
+      register: __transactional_update_stat
+
+    - name: Set flag if transactional-update exists
+      set_fact:
+        __sudo_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"
   loop:


### PR DESCRIPTION
Enhancement: - Added a block to identify and handle reboots for transactional update systems on package changes. Update README and minor fix in README example.

Reason: Ensure necessary reboots are managed, as changes on transactional update systems are applied in a separate snapshot and require a reboot to take effect.

Result: Manages system reboots for transactional update systems when a package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
