### PR TITLE
ci: Add tags to TF workflow, allow more [citest bad] formats

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -48,6 +48,11 @@ jobs:
           PR_NO: ${{ github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.head_sha.outputs.head_sha }}
+
       - name: Get memory
         id: memory
         run: |
@@ -113,7 +118,7 @@ jobs:
       ARTIFACTS_DIR_NAME: "tf_${{ github.event.repository.name }}-${{ github.event.issue.number }}_\
         ${{ matrix.platform }}-${{ matrix.ansible_version }}_\
         ${{ needs.prepare_vars.outputs.datetime }}/artifacts"
-      ARTIFACT_TARGET_DIR: /srv/pub/alt/linuxsystemroles/logs
+      ARTIFACT_TARGET_DIR: /srv/pub/alt/${{ vars.LINUXSYSTEMROLES_USER }}/logs
     steps:
       - name: Set variables with DATETIME and artifact location
         id: set_vars
@@ -121,9 +126,9 @@ jobs:
           printf -v DATETIME '%(%Y%m%d-%H%M%S)T' -1
           ARTIFACTS_DIR_NAME="tf_${{ github.event.repository.name }}-${{ github.event.issue.number }}_\
           ${{ matrix.platform }}-${{ matrix.ansible_version }}_$DATETIME/artifacts"
-          ARTIFACTS_TARGET_DIR=/srv/pub/alt/linuxsystemroles/logs
+          ARTIFACTS_TARGET_DIR=/srv/pub/alt/${{ vars.LINUXSYSTEMROLES_USER }}/logs
           ARTIFACTS_DIR=$ARTIFACTS_TARGET_DIR/$ARTIFACTS_DIR_NAME
-          ARTIFACTS_URL=https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs$ARTIFACTS_DIR_NAME
+          ARTIFACTS_URL=https://dl.fedoraproject.org/pub/alt/${{ vars.LINUXSYSTEMROLES_USER }}/logs/$ARTIFACTS_DIR_NAME
           echo "DATETIME=$DATETIME" >> $GITHUB_OUTPUT
           echo "ARTIFACTS_DIR=$ARTIFACTS_DIR" >> $GITHUB_OUTPUT
           echo "ARTIFACTS_URL=$ARTIFACTS_URL" >> $GITHUB_OUTPUT
@@ -155,17 +160,18 @@ jobs:
           git_url: https://github.com/linux-system-roles/tft-tests
           git_ref: main
           pipeline_settings: '{ "type": "tmt-multihost" }'
+          environment_settings: '{ "provisioning": { "tags": { "BusinessUnit": "system_roles" } } }'
+          # Keeping ARTIFACTS_URL at the bottom makes the link in logs clickable
           variables: "ANSIBLE_VER=${{ matrix.ansible_version }};\
             REPO_NAME=${{ github.event.repository.name }};\
             GITHUB_ORG=${{ github.repository_owner }};\
-            GITHUB_ORG=linux-system-roles;\
             PR_NUM=${{ github.event.issue.number }};\
             ARTIFACTS_DIR=${{ steps.set_vars.outputs.ARTIFACTS_DIR }};\
-            ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }};\
-            TEST_LOCAL_CHANGES=false"
+            TEST_LOCAL_CHANGES=false;\
+            LINUXSYSTEMROLES_USER=${{ vars.LINUXSYSTEMROLES_USER }};\
+            ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.
-          secrets: "LINUXSYSTEMROLES_USER=${{ secrets.LINUXSYSTEMROLES_USER }};\
-            LINUXSYSTEMROLES_DOMAIN=${{ secrets.LINUXSYSTEMROLES_DOMAIN }};\
+          secrets: "LINUXSYSTEMROLES_DOMAIN=${{ secrets.LINUXSYSTEMROLES_DOMAIN }};\
             LINUXSYSTEMROLES_SSH_KEY=${{ secrets.LINUXSYSTEMROLES_SSH_KEY }}"
           compose: ${{ matrix.platform }}
           # There are two blockers for using public ranch:
@@ -175,6 +181,7 @@ jobs:
           api_key: ${{ secrets.TF_API_KEY_RH }}
           update_pull_request_status: false
           tmt_hardware: '{ "memory": ">= ${{ needs.prepare_vars.outputs.memory }} MB" }'
+          tmt_plan_filter: "tag:general,sudo"
 
       - name: Set final commit status
         uses: myrotvorets/set-commit-status-action@master

--- a/.github/workflows/tft_citest_bad.yml
+++ b/.github/workflows/tft_citest_bad.yml
@@ -10,7 +10,7 @@ jobs:
   citest_bad_rerun:
     if: |
       github.event.issue.pull_request
-      && github.event.comment.body == '[citest_bad]'
+      && contains(fromJson('["[citest_bad]", "[citest-bad]", "[citest bad]"]'), github.event.comment.body)
       && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
     permissions:
       actions: write # for re-running failed jobs: https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#re-run-a-job-from-a-workflow-run


### PR DESCRIPTION
* Add "BusinessUnit": "system_roles" environment setting to tag our jobs in Testing farm
* Add tmt_plan_filter to run additional workflows besides general
* Allow more [citest bad] comment formats
* Get memory and supported platforms info from the PR ref
* Move LINUXSYSTEMROLES_USER to vars and use it everywhere in tft.yml
* Remove extra GITHUB_ORG definition

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
