### PR TITLE
ci: Drop explicit "connection:" for provisioning

### DIFF
--- a/plans/test_playbooks_parallel.fmf
+++ b/plans/test_playbooks_parallel.fmf
@@ -5,16 +5,10 @@ provision:
   # Hence there is no need to define `how` explicitly.
   - name: control-node1
     role: control_node
-    # `connection: system` is required for `how: virtual` to assign VMs a real
-    # IP making SSH configuration easier.
-    # This setting is ignored in `artemis`, so we can leave it as is.
-    connection: system
   - name: managed-node1
     role: managed_node
-    connection: system
   - name: managed-node2
     role: managed_node
-    connection: system
 environment:
   SR_ANSIBLE_VER: 2.17
   SR_REPO_NAME: sudo


### PR DESCRIPTION
This forces having to have a system libvirt instance, but that is incompatible with running tests inside of containers/toolbox. It also seems unnecessary: session libvirt networking and the tests work just fine.

Drop the explicit setting and let tmt/testcloud pick its internal default (which is `qemu:///session`). This wasn't relevant for running on Testing Farm anyway.

Enhancement: tmt tests can now be run locally out of a container or toolbox.

Reason: Requiring a system libvirtd instance is an unnecessary requirement (e.g. my laptop doesn't have libvirtd installed at all, I run everything in toolbox). `tmt` defaults to `qemu:///session` for this reason, which is much more flexible and safer, and less demanding.

Result:

Issue Tracker Tickets (Jira or BZ if any): -

`tmt run --until report provision --how virtual --image fedora-42` succeeds for me now. It previously failed with

    libvirt: XML-RPC error : Failed to connect socket to '/var/run/libvirt/virtqemud-sock': No such file or directory


Being able to run `tmt` locally is quite important for me, especially as tmt tests don't run by default in PRs -- they need to be explicitly requested by project maintainers. I am not one, and it's actually useful to be in that state for a while to ensure that the experience for external contributors is good enough.