### PR TITLE
ci: Add Python 3.12

### DIFF
--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -21,8 +21,6 @@ jobs:
         pyver_os:
           - ver: "2.7"
             os: ubuntu-22.04
-          - ver: "3.8"
-            os: ubuntu-latest
           - ver: "3.9"
             os: ubuntu-latest
           - ver: "3.10"
@@ -65,7 +63,7 @@ jobs:
             tox=tox
             virtualenv=virtualenv
           fi
-          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.4.0"
+          pip install "$tox" "$virtualenv" "git+https://github.com/linux-system-roles/tox-lsr@3.5.1"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -27,6 +27,8 @@ jobs:
             os: ubuntu-latest
           - ver: "3.11"
             os: ubuntu-latest
+          - ver: "3.12"
+            os: ubuntu-latest
     runs-on: ${{ matrix.pyver_os.os }}
     steps:
       - name: Update git


### PR DESCRIPTION
For covering Fedora 41/42, and they may also be added to RHEL 9 at some point.
 
3.13 is not yet supported by all Ansible tools:
    
> py313: failed with env name py313 conflicting with base python python3
    
So don't add this for now.

-----

Testing here first, then will submit to .github.git.

 - [x] https://github.com/linux-system-roles/tox-lsr/pull/178
 - [x] https://github.com/linux-system-roles/tox-lsr/pull/181
 - [x]  preliminarily bump dependency here to the SHA that's equivalent to 3.5.0
 - [x] Release tox-lsr 3.5.1
 - [x] https://github.com/linux-system-roles/.github/pull/97