### PR TITLE
ci: skip storage scsi, nvme tests in github qemu ci

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -86,7 +86,7 @@ jobs:
         if: steps.check_platform.outputs.supported
         run: >-
           tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level=debug --skip-tags tests::infiniband --
+          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
 
       - name: Test result summary
         if: steps.check_platform.outputs.supported && always()


### PR DESCRIPTION
These tests are problematic in github qemu tests, and that
functionality (scsi, anyway) in the testing farm integration
tests.

Yes, we should have a way to provide tags on a per-role basis . . .

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
