### PR TITLE
ci: Add container integration test for rpm and bootc

### DIFF
--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -1,5 +1,5 @@
 ---
-name: QEMU/KVM Integration tests
+name: Test
 on:  # yamllint disable-line rule:truthy
   pull_request:
   merge_group:
@@ -17,18 +17,34 @@ permissions:
   # This is required for the ability to create/update the Pull request status
   statuses: write
 jobs:
-  qemu_kvm:
+  scenario:
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         scenario:
+          # QEMU
           - { image: "centos-9", env: "qemu-ansible-core-2.16" }
           - { image: "centos-10", env: "qemu-ansible-core-2.17" }
           # ansible/libdnf5 bug: https://issues.redhat.com/browse/RHELMISC-10110
           # - { image: "fedora-41", env: "qemu-ansible-core-2.17" }
           - { image: "fedora-42", env: "qemu-ansible-core-2.17" }
+
+          # container
+          - { image: "centos-9", env: "container-ansible-core-2.16" }
+          - { image: "centos-9-bootc", env: "container-ansible-core-2.16" }
+          # broken on non-running dbus
+          # - { image: "centos-10", env: "container-ansible-core-2.17" }
+          - { image: "centos-10-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-41", env: "container-ansible-core-2.17" }
+          - { image: "fedora-42", env: "container-ansible-core-2.17" }
+          - { image: "fedora-41-bootc", env: "container-ansible-core-2.17" }
+          - { image: "fedora-42-bootc", env: "container-ansible-core-2.17" }
+
+    env:
+      TOX_ARGS: "--skip-tags tests::infiniband,tests::nvme,tests::scsi"
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -38,6 +54,7 @@ jobs:
         run: |
           set -euxo pipefail
           image="${{ matrix.scenario.image }}"
+          image="${image%-bootc}"
 
           # convert image to tag formats
           platform=
@@ -49,6 +66,20 @@ jobs:
           supported=
           if yq -e '.galaxy_info.galaxy_tags[] | select(. == "'${platform_version}'" or . == "'${platform}'")' meta/main.yml; then
             supported=true
+          fi
+
+          # bootc build support (in buildah) has a separate flag
+          if [ "${{ matrix.scenario.image }}" != "$image" ]; then
+            if ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "containerbuild")' meta/main.yml; then
+              supported=
+            fi
+          else
+            # roles need to opt into support for running in a system container
+            env="${{ matrix.scenario.env }}"
+            if [ "${env#container}" != "$env" ] &&
+              ! yq -e '.galaxy_info.galaxy_tags[] | select(. == "container")' meta/main.yml; then
+              supported=
+            fi
           fi
 
           echo "supported=$supported" >> "$GITHUB_OUTPUT"
@@ -82,14 +113,13 @@ jobs:
           curl -o ~/.config/linux-system-roles.json
           https://raw.githubusercontent.com/linux-system-roles/linux-system-roles.github.io/master/download/linux-system-roles.json
 
-      - name: Run qemu/kvm tox integration tests
-        if: steps.check_platform.outputs.supported
-        run: >-
-          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch
-          --log-level=debug --skip-tags tests::infiniband,tests::nvme,tests::scsi --
+      - name: Run qemu integration tests
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu')
+        run: |
+          tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} --make-batch $TOX_ARGS --
 
-      - name: Test result summary
-        if: steps.check_platform.outputs.supported && always()
+      - name: Qemu result summary
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'qemu') && always()
         run: |
           set -euo pipefail
           # some platforms may have setup/cleanup playbooks - need to find the
@@ -108,6 +138,24 @@ jobs:
               fi
               echo "$f"
           done < batch.report
+
+      - name: Run container tox integration tests
+        if: steps.check_platform.outputs.supported && startsWith(matrix.scenario.env, 'container')
+        run: |
+          set -euo pipefail
+          # HACK: debug.py/profile.py setup is broken
+          export LSR_CONTAINER_PROFILE=false
+          export LSR_CONTAINER_PRETTY=false
+          rc=0
+          for t in tests/tests_*.yml; do
+              if tox -e ${{ matrix.scenario.env }} -- --image-name ${{ matrix.scenario.image }} $t > ${t}.log 2>&1; then
+                  echo "PASS: $(basename $t)"
+              else
+                  echo "FAIL: $(basename $t)"
+                  rc=1
+              fi
+          done
+          exit $rc
 
       - name: Upload test logs on failure
         if: failure()
@@ -139,6 +187,6 @@ jobs:
         uses: myrotvorets/set-commit-status-action@master
         with:
           status: success
-          context: "${{ github.workflow }} / qemu_kvm (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
+          context: "${{ github.workflow }} / scenario (${{ matrix.scenario.image }}, ${{ matrix.scenario.env }}) (pull_request)"
           description: The role does not support this platform. Skipping.
           targetUrl: ""

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,4 +19,6 @@ galaxy_info:
     - el9
     - el10
     - fedora
+    - container
+    - containerbuild
 dependencies: []


### PR DESCRIPTION
Generalize qemu-kvm-integration-tests.yml to run some "container-*" environments as well. For "classic rpm" OSes that does not give us too much beyond making sure that the container tests actually work (developers might use them locally, after all). 90% of the logic (setup, compatibility check, status updates, etc.) is the same, so it's not economic to duplicate all of that into a new workflow.

Add Fedora/CentOS *-bootc scenarios: These check that our role works during a bootc container build, without any systemd, processes, or other runtime environment. tox-lsr added support for this in https://github.com/linux-system-roles/tox-lsr/pull/188.

However, as most roles don't currently work in that environment, introduce and check a new `containerbuild` tag in meta/main.yml. We'll add this to roles as we adjust them.

Similarly, as not every role works in a running container (e.g. due to assuming SELinux), check a new `container` tag in their tests.

Issue Tracker Tickets (Jira or BZ if any): https://issues.redhat.com/browse/RHEL-85652

----

 - [x] Test this with failing tests, to check log parsing and artifact attachments: [extra commit which breaks tests](https://github.com/martinpitt/lsr-sudo/commit/362effcb54d9d474817bd90bb827ad795f5c6a8b), [failed test run](https://github.com/martinpitt/lsr-sudo/actions/runs/14621692600)
 - [x] Land #53, then rebase
 - [x] https://github.com/linux-system-roles/linux-system-roles.github.io/pull/121
 - [x] https://github.com/linux-system-roles/linux-system-roles.github.io/pull/122
 - [x] Send fix for missing python3-libdnf5 in Fedora bootc base containers: https://gitlab.com/fedora/bootc/base-images/-/merge_requests/167
 - [x] Work around missing p-libdnf5 in tox-lsr, until the above MR lands: https://github.com/linux-system-roles/tox-lsr/pull/189
 - [x] Add mechanism to skip tests which cover scenarios which are unsupportable in a container build (done: `tags::booted`)
 - [x] Add fedora bootc test scenario
 - [x] Test this against role with a service: https://github.com/linux-system-roles/cockpit/pull/212 and https://github.com/linux-system-roles/logging/pull/444 and https://github.com/linux-system-roles/firewall/pull/264
 - [x] Add and check a `containerbuild` tag, so that we can start introducing these tests to all roles and allow us to fix them individually.
 - [ ] Once everything is ready, file PR against .github.git
