### PR TITLE
docs(changelog): version 1.2.3 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }
@@ -623,12 +624,18 @@ alt="ansible-test.yml" /></a> <a
 href="https://github.com/linux-system-roles/sudo/actions/workflows/codeql.yml"><img
 src="https://github.com/linux-system-roles/sudo/actions/workflows/codeql.yml/badge.svg"
 alt="codeql.yml" /></a> <a
+href="https://github.com/linux-system-roles/sudo/actions/workflows/codespell.yml"><img
+src="https://github.com/linux-system-roles/sudo/actions/workflows/codespell.yml/badge.svg"
+alt="codespell.yml" /></a> <a
 href="https://github.com/linux-system-roles/sudo/actions/workflows/markdownlint.yml"><img
 src="https://github.com/linux-system-roles/sudo/actions/workflows/markdownlint.yml/badge.svg"
 alt="markdownlint.yml" /></a> <a
 href="https://github.com/linux-system-roles/sudo/actions/workflows/python-unit-test.yml"><img
 src="https://github.com/linux-system-roles/sudo/actions/workflows/python-unit-test.yml/badge.svg"
 alt="python-unit-test.yml" /></a> <a
+href="https://github.com/linux-system-roles/sudo/actions/workflows/qemu-kvm-integration-tests.yml"><img
+src="https://github.com/linux-system-roles/sudo/actions/workflows/qemu-kvm-integration-tests.yml/badge.svg"
+alt="qemu-kvm-integration-tests.yml" /></a> <a
 href="https://github.com/linux-system-roles/sudo/actions/workflows/shellcheck.yml"><img
 src="https://github.com/linux-system-roles/sudo/actions/workflows/shellcheck.yml/badge.svg"
 alt="shellcheck.yml" /></a> <a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Changelog
 =========
 
+[1.2.3] - 2025-05-21
+--------------------
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#36)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#39)
+- refactor: fix python black formatting (#40)
+- ci: Check spelling with codespell (#41)
+- ci: Add test plan that runs CI tests and customize it for each role (#42)
+- ci: In test plans, prefix all relate variables with SR_ (#43)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#44)
+- ci: Drop explicit "connection:" for provisioning (#45)
+- ci: Run QEMU tox integration tests in GitHub workflow (#46)
+- ci: Add Python 3.12 (#47)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#48)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#50)
+- ci: skip storage scsi, nvme tests in github qemu ci (#51)
+- ci: Add container integration test for rpm and bootc (#52)
+- ci: Update to tox-lsr 3.7.0 (#53)
+- ci: bump sclorg/testing-farm-as-github-action from 3 to 4 (#54)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#55)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#56)
+
 [1.2.2] - 2025-01-09
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.2.3

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Document the 1.2.3 release by updating the changelog, refining README HTML styles, and adding new CI workflow badges

Documentation:
- Add a 1.2.3 changelog entry summarizing CI enhancements and formatting fixes
- Adjust README.html CSS rules for improved code block rendering
- Include codespell and QEMU-KVM integration test badges in README HTML