### PR TITLE
fix: Avoid setting ansible_managed variable

### DIFF
--- a/tests/tasks/check_not_present_header.yml
+++ b/tests/tasks/check_not_present_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed not in content
+      - __ansible_managed not in content
       - __fingerprint not in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/tasks/check_present_header.yml
+++ b/tests/tasks/check_present_header.yml
@@ -9,8 +9,8 @@
 - name: Check for presence of ansible managed header, fingerprint
   assert:
     that:
-      - ansible_managed in content
+      - __ansible_managed in content
       - __fingerprint in content
   vars:
     content: "{{ (__file_content | d(__content)).content | b64decode }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    __ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"


### PR DESCRIPTION
Cause: The test used a temporary variable `ansible_managed`, but that is a "magic" string constant. Ansible 2.19 does not permit assigning to it any more.

Consequence: Tests failed with Ansible 2.19.

Fix: Rename the variable.

---

This should fix the [F42/Ansible 2.19 failure](https://github.com/linux-system-roles/sudo/actions/runs/15545983752/job/43767413229) introduced in #60

## Summary by Sourcery

Prevent tests from assigning to the reserved ansible_managed variable to restore compatibility with Ansible 2.19

Bug Fixes:
- Rename the temporary ansible_managed variable to __ansible_managed in tests to avoid conflicts

Tests:
- Update check_present_header.yml and check_not_present_header.yml to use __ansible_managed in assertions and vars