### PR TITLE
fix: Avoid append() in sudoers file template

### DIFF
--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -1,30 +1,17 @@
 {%- macro render_aliases(alias_desc,alias_str,alias_dict,alias_subdict_name) %}
-{%   if item.aliases[alias_dict] is defined %}
+{% if item.aliases[alias_dict] is defined %}
 
 ## {{ alias_desc }}
-{%     for alias_item in item.aliases[alias_dict] %}
-{%       set _alias = [] %}
-{%       for alias_val in alias_item[alias_subdict_name] %}
-{%         set _ = _alias.append(alias_val) %}
-{%       endfor %}
-{{ alias_str }}    {{ alias_item.name }} = {{ _alias | join(", ") }}
-{%     endfor %}
-{%   endif %}
-{% endmacro -%}
+{%   for alias_item in item.aliases[alias_dict] %}
+{{ alias_str }}    {{ alias_item.name }} = {{ alias_item[alias_subdict_name] | join(", ") }}
+{%   endfor %}
+{% endif %}
+{%- endmacro -%}
 {%- macro render_override_spec(spec,spec_type, spec_dict, sign) %}
-{%   if spec.type == spec_type %}
-{%     set _spec_original = [] %}
-{%     set _spec_default = [] %}
-{%       for spec_original in spec[spec_dict] %}
-{%         set _ = _spec_original.append(spec_original) %}
-{%       endfor %}
-{%       for spec_default in spec.defaults %}
-{%         set _ = _spec_default.append(spec_default) %}
-{%       endfor %}
-Defaults{{ sign }} {{ _spec_original | join(", ") }} {{ _spec_default |
-  join(", ") }}
-{%    endif %}
-{% endmacro -%}
+{% if spec.type == spec_type %}
+Defaults{{ sign }} {{ spec[spec_dict] | join(", ") }} {{ spec.defaults | join(", ") }}
+{% endif %}
+{%- endmacro -%}
 {{ ansible_managed | default('Ansible managed') | comment }}
 {{ "system_role:sudo" | comment(prefix="", postfix="") }}
 {%- if item.defaults is defined %}
@@ -34,11 +21,7 @@ Defaults{{ sign }} {{ _spec_original | join(", ") }} {{ _spec_default |
 {%     if default is mapping %}
 {%       for name, values in default.items() %}
 {%         if name == 'secure_path' %}
-{%           set paths = [] %}
-{%           for my_value in values %}
-{%             set _ = paths.append(my_value) %}
-{%           endfor %}
-Defaults    {{ name }} = {{ paths | join(":") }}
+Defaults    {{ name }} = {{ values | join(":") }}
 {%         else %}
 {%           for items in values | list | slice(6) %}
 {%             if items %}
@@ -70,79 +53,30 @@ Defaults    {{ default }}
 
 # User specifications
 {%   for spec in item.user_specifications %}
-{%     set user_spec = [] %}
-{%     set spec_users = [] %}
-{%     set spec_hosts = [] %}
-{%     set spec_ops = [] %}
-{%     set spec_types = [] %}
-{%     set spec_roles = [] %}
-{%     set spec_privs = [] %}
-{%     set spec_lprivs = [] %}
-{%     set spec_tags = [] %}
-{%     set spec_cmnds = [] %}
-{%     for user in spec.users %}
-{%       set _ = spec_users.append(user) %}
-{%     endfor %}
-{%     set _ = user_spec.append(spec_users | join(", ")) %}
-{%     set _ = user_spec.append(" ") %}
-{%     for host in spec.hosts %}
-{%       set _ = spec_hosts.append(host) %}
-{%     endfor %}
-{%     set _ = user_spec.append(spec_hosts | join(", ")) %}
-{%     set _ = user_spec.append("=") %}
-{%     if spec.operators is defined %}
-{%       set _ = user_spec.append("(") %}
-{%       for op in spec.operators %}
-{%         set _ = spec_ops.append(op) %}
-{%       endfor %}
-{%     set _ = user_spec.append(spec_ops | join(", ")) %}
-{%     set _ = user_spec.append(")") %}
+{%     if spec.users is defined and spec.users | length > 0
+          and spec.hosts is defined and spec.hosts | length > 0
+          and spec.commands is defined and spec.commands | length > 0 %}
+{{ spec.users | join(", ") }} {{ spec.hosts | join(", ") }}=
+{%- if spec.operators is defined and spec.operators | length > 0 -%}
+({{ spec.operators | join(", ") }})
+{%- endif -%}
+{%- if spec.selinux_type is defined and spec.selinux_type | length > 0 -%}
+ TYPE={{ spec.selinux_type | join(", ") }}
+{%- endif -%}
+{%- if spec.selinux_role is defined and spec.selinux_role | length > 0 -%}
+ ROLE={{ spec.selinux_role | join(", ") }}
+{%- endif -%}
+{%- if spec.solaris_privs is defined and spec.solaris_privs | length > 0 -%}
+ PRIVS={{ spec.solaris_privs | join(", ") }}
+{%- endif -%}
+{%- if spec.solaris_limitprivs is defined and spec.solaris_limitprivs | length > 0 -%}
+ LIMITPRIVS={{ spec.solaris_limitprivs | join(", ") }}
+{%- endif -%}
+{%- if spec.tags is defined and spec.tags | length > 0 -%}
+{{ spec.tags | join(":") }}:
+{%- endif -%}
+{{ " " + spec.commands | join(", ") }}
 {%     endif %}
-{%     set _ = user_spec.append(" ") %}
-{%     if spec.selinux_type is defined %}
-{%       set _ = user_spec.append("TYPE=") %}
-{%       for type in spec.selinux_type %}
-{%         set _ = spec_types.append(type) %}
-{%       endfor %}
-{%       set _ = user_spec.append(spec_types | join(", ")) %}
-{%       set _ = user_spec.append(" ") %}
-{%     endif %}
-{%     if spec.selinux_role is defined %}
-{%       set _ = user_spec.append("ROLE=") %}
-{%       for role in spec.selinux_role %}
-{%         set _ = spec_roles.append(role) %}
-{%       endfor %}
-{%       set _ = user_spec.append(spec_roles | join(", ")) %}
-{%       set _ = user_spec.append(" ") %}
-{%     endif %}
-{%     if spec.solaris_privs is defined %}
-{%       set _ = user_spec.append("PRIVS=") %}
-{%       for priv in spec.solaris_privs %}
-{%         set _ = spec_privs.append(priv) %}
-{%       endfor %}
-{%       set _ = user_spec.append(spec_privs | join(", ")) %}
-{%       set _ = user_spec.append(" ") %}
-{%     endif %}
-{%     if spec.solaris_limitprivs is defined %}
-{%       set _ = user_spec.append("LIMITPRIVS=") %}
-{%       for lpriv in spec.solaris_limitprivs %}
-{%         set _ = spec_lprivs.append(lpriv) %}
-{%       endfor %}
-{%       set _ = user_spec.append(spec_lprivs | join(", ")) %}
-{%       set _ = user_spec.append(" ") %}
-{%     endif %}
-{%     if spec.tags is defined %}
-{%       for tag in spec.tags %}
-{%         set _ = spec_tags.append(tag) %}
-{%       endfor %}
-{%       set _ = user_spec.append(spec_tags | join(":")) %}
-{%       set _ = user_spec.append(": ") %}
-{%     endif %}
-{%     for cmnd in spec.commands %}
-{%       set _ = spec_cmnds.append(cmnd) %}
-{%     endfor %}
-{%     set _ = user_spec.append(spec_cmnds | join(", ")) %}
-{{ user_spec | join('') }}
 {%   endfor %}
 {% endif -%}
 {%- if item.default_overrides is defined %}


### PR DESCRIPTION
Cause: Ansible 2.19 does not allow calling `.append()` on a list any more (https://github.com/ansible/ansible/issues/85202). You also can't reassign variables in a loop, so list addition does not work either.

Consequence: The role failed on Ansible 2.19.

Fix: Rewrite the template to using filters instead of explicit dict iteration.


----

This is supposed to fix the [Ansible 2.19 failure](https://github.com/linux-system-roles/sudo/actions/runs/15653347268/job/44101051151). It took me *hours* to get the spacing exactly right, but I developed this against 2.17 (to make sure I don't regress). Turns out in 2.19 it is *still* making a mess, and I don't know how. Parking my current state as draft PR, today I don't have the energy to work on this further.