### PR TITLE
fix: ensure single space before TYPE, ROLE, and correctly format those values

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,14 @@ You can use a defined `host_alias` name as well as host names.
 You can use a defined `runas_alias` name as well as user names.
 
 4. `selinux_role` - Optional selinux role to apply to the specification.
+   **NOTE** - only a single value is supported.  However, due to historical
+   reasons, the value can be a list - if a list is given, only the first value
+   is used.  Please use a `string` value.
 
 5. `selinux_type` - Optional selinux type to apply to the specification.
+   **NOTE** - only a single value is supported.  However, due to historical
+   reasons, the value can be a list - if a list is given, only the first value
+   is used.  Please use a `string` value.
 
 6. `solaris_privs` - Optional Solaris privset to apply to the specification.
 
@@ -192,6 +198,8 @@ sudo_sudoers_files:
           - ALL
         commands:
           - ALL
+        selinux_role: sysadm_r
+        selinux_type: sysadm_t
 ```
 
 #### default_overrides

--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -64,17 +64,17 @@ Defaults    {{ default }}
 {%- if spec.operators is defined and spec.operators | length > 0 -%}
 ({{ spec.operators | join(", ") }})
 {%- endif -%}
-{%- if spec.selinux_type is defined and spec.selinux_type | length > 0 -%}
- TYPE={{ spec.selinux_type | join(", ") }}
+{%- if spec.selinux_type is defined and spec.selinux_type | length > 0 %}
+ TYPE={{ spec.selinux_type if spec.selinux_type is string else spec.selinux_type[0] }}
 {%- endif -%}
-{%- if spec.selinux_role is defined and spec.selinux_role | length > 0 -%}
- ROLE={{ spec.selinux_role | join(", ") }}
+{%- if spec.selinux_role is defined and spec.selinux_role | length > 0 %}
+ ROLE={{ spec.selinux_role if spec.selinux_role is string else spec.selinux_role[0] }}
 {%- endif -%}
-{%- if spec.solaris_privs is defined and spec.solaris_privs | length > 0 -%}
- PRIVS={{ spec.solaris_privs | join(", ") }}
+{%- if spec.solaris_privs is defined and spec.solaris_privs | length > 0 %}
+ PRIVS={{ spec.solaris_privs | join(",") }}
 {%- endif -%}
-{%- if spec.solaris_limitprivs is defined and spec.solaris_limitprivs | length > 0 -%}
- LIMITPRIVS={{ spec.solaris_limitprivs | join(", ") }}
+{%- if spec.solaris_limitprivs is defined and spec.solaris_limitprivs | length > 0 %}
+ LIMITPRIVS={{ spec.solaris_limitprivs | join(",") }}
 {%- endif -%}
 {%- if spec.tags is defined and spec.tags | length > 0 -%}
 {{ spec.tags | join(":") }}:

--- a/tests/files/tests_large_configuration_sudoers.ok
+++ b/tests/files/tests_large_configuration_sudoers.ok
@@ -33,7 +33,7 @@ User_Alias    PINGERS = username
 
 # User specifications
 root ALL=(ALL) ALL
-%wheel ALL=(ALL) ALL
+%wheel ALL=(ALL) TYPE=sysadm_t ROLE=sysadm_r /bin/pwd, /usr/bin/cd
 
 # Default override specifications
 Defaults: PINGERS !requiretty

--- a/tests/tests_large_configuration.yml
+++ b/tests/tests_large_configuration.yml
@@ -71,8 +71,11 @@
                       - ALL
                     operators:
                       - ALL
+                    selinux_type: sysadm_t
+                    selinux_role: sysadm_r
                     commands:
-                      - ALL
+                      - /bin/pwd
+                      - /usr/bin/cd
                 default_overrides:
                   - type: user
                     defaults:


### PR DESCRIPTION
Cause: The recent refactoring for Ansible 2.19 altered the whitespacing before
the TYPE and ROLE values.  In addition, the TYPE and ROLE values are a single
string, not a comma delimited list.  We did not have any tests for these
values, so we did not catch the error in the refactoring.

Consequence: The role would incorrectly format the TYPE and ROLE values.

Fix: Use correct Jinja formatting for the TYPE and ROLE values, and the
solaris values.  Ensure that the TYPE and ROLE values will be a single string.

Result: The sudoers file is correctly formatted.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Fix whitespace and value formatting in the sudoers Jinja template for TYPE, ROLE, PRIVS, and LIMITPRIVS; add tests to cover selinux_type and selinux_role and refresh fixtures.

Bug Fixes:
- Correct rendering of TYPE and ROLE as single values with a leading space instead of comma-separated lists.
- Remove extraneous spaces in Solaris PRIVS and LIMITPRIVS filters by joining without added spaces.

Tests:
- Add selinux_type and selinux_role entries and specific commands to the large configuration tests.
- Refresh the expected sudoers output fixture to validate the updated formatting.