### PR TITLE
fix: enable CI tests for openSUSE leap; handle missing /etc/sudoers

### DIFF
--- a/library/scan_sudoers.py
+++ b/library/scan_sudoers.py
@@ -168,7 +168,7 @@ def get_includes(path):
 
 def get_config_lines(path, params):
     # Read sudoers file
-    if not os.path.isfile(path):
+    if not isfile(path):
         return {}
     fp = open(path, "r")
     all_lines = fp.read()

--- a/library/scan_sudoers.py
+++ b/library/scan_sudoers.py
@@ -168,6 +168,8 @@ def get_includes(path):
 
 def get_config_lines(path, params):
     # Read sudoers file
+    if not os.path.isfile(path):
+        return {}
     fp = open(path, "r")
     all_lines = fp.read()
     fp.close()

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -2,3 +2,5 @@
 ---
 collections:
   - name: ansible.posix
+  - name: community.general
+    version: ">=6.6.0,<12.0.0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,7 @@ galaxy_info:
     - el9
     - el10
     - fedora
+    - leap
     - container
     - containerbuild
 dependencies: []

--- a/tests/unit/test_scan_sudoers.py
+++ b/tests/unit/test_scan_sudoers.py
@@ -334,7 +334,8 @@ Defaults env_keep += \"COLORS DISPLAY\"
         "scan_sudoers.get_includes",
         return_value={"include_files": ["/etc/sudoers.d/file1"]},
     )
-    def test_get_config_lines01(self, mock_open, mock_get_includes):
+    @patch("scan_sudoers.isfile", return_value=True)
+    def test_get_config_lines01(self, mock_isfile, mock_open, mock_get_includes):
         # Arrange
 
         params = {"output_raw_configs": True, "output_parsed_configs": True}
@@ -395,7 +396,8 @@ monitor ALL=(ALL:ALL) SYSTEM_CMDS
         "scan_sudoers.get_includes",
         return_value={"include_files": ["/etc/sudoers.d/file1"]},
     )
-    def test_get_config_lines02(self, mock_open, mock_get_includes):
+    @patch("scan_sudoers.isfile", return_value=True)
+    def test_get_config_lines02(self, mock_isfile, mock_open, mock_get_includes):
         # Arrange
         params = {"output_raw_configs": True, "output_parsed_configs": True}
         expected_output = {


### PR DESCRIPTION
Enhancement: Enable openSUSE Leap CI testing and fix scan_sudoers crash 

Reason: CI tests dont run on openSUSE Leap & scan_sudoers crashes with filenotfounderror on systems using config pattern (/usr/etc/sudoers) eg sles16/leap16/tumbleweed, causing the role to fail before it can run. fix added os.path.isfile() check in scan_sudoers.py. 

Result: CI test to be enabled for Leap. scan_sudoers does not crash with FileNotFoundError. 

Issue Tracker Tickets (Jira or BZ if any): na

## Summary by Sourcery

Enable openSUSE Leap support and prevent sudoers scanning from failing when the sudoers file is missing.

Bug Fixes:
- Avoid crashing in sudoers scanning when the configured sudoers file path does not exist.

Enhancements:
- Declare openSUSE Leap as a supported platform and ensure its CI tests can run by updating collection requirements.