### PR TITLE
feat: add role fingerprints to syslog

### DIFF
--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.16.txt
+++ b/.sanity-ansible-ignore-2.16.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.17.txt
+++ b/.sanity-ansible-ignore-2.17.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.18.txt
+++ b/.sanity-ansible-ignore-2.18.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.19.txt
+++ b/.sanity-ansible-ignore-2.19.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.20.txt
+++ b/.sanity-ansible-ignore-2.20.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.21.txt
+++ b/.sanity-ansible-ignore-2.21.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.22.txt
+++ b/.sanity-ansible-ignore-2.22.txt
@@ -1,0 +1,1 @@
+plugins/modules/sr_fingerprint.py validate-modules:missing-gplv3-license

--- a/library/sr_fingerprint.py
+++ b/library/sr_fingerprint.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: sr_fingerprint
+short_description: Write a message string to syslog using Ansible C(module.log) function.
+description:
+    - Writes the given string to the system log using Ansible C(module.log) function.
+    - Intended for role-internal or diagnostic use.
+author: Rich Megginson (@richm)
+options:
+    sr_message:
+        description: Text to record in syslog.
+        type: str
+        required: true
+"""
+
+EXAMPLES = """
+- name: Record a fingerprint message in syslog
+  sr_fingerprint:
+    sr_message: "system_role:ROLENAME"
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+import datetime
+
+
+def _local_iso8601_no_microseconds():
+    """System local wall clock with local tz offset, ISO 8601, seconds only."""
+    try:
+        utc = datetime.timezone.utc
+    except AttributeError:
+        import time
+
+        return time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime())
+    # Prefer the local clock interpreted in the system timezone (not UTC displayed).
+    now = datetime.datetime.now()
+    astimezone = getattr(now, "astimezone", None)
+    if astimezone is not None:
+        try:
+            return astimezone().replace(microsecond=0).isoformat()
+        except (OSError, TypeError, ValueError):
+            pass
+    return datetime.datetime.now(utc).astimezone().replace(microsecond=0).isoformat()
+
+
+def run_module():
+    module_args = dict(
+        sr_message=dict(type="str", required=True),
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    log_message = "%s %s" % (
+        module.params["sr_message"],
+        _local_iso8601_no_microseconds(),
+    )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=False,
+            message="Check mode: message not logged - [%s]" % log_message,
+        )
+
+    module.log(log_message)
+
+    # we don't actually change anything, so we're not changed - writing a log message
+    # is not considered a change
+    # also, we don't want to report changed every time the role runs
+    module.exit_json(changed=False)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,3 +125,9 @@
         state: absent
       with_items: "{{ sudo_unauthorized_files }}"
       when: sudo_unauthorized_files | length > 0
+
+- name: Record role success fingerprint
+  sr_fingerprint:
+    sr_message: >-
+      success system_role:sudo ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -5,6 +5,12 @@
   when: __sudo_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
+- name: Record role begin fingerprint
+  sr_fingerprint:
+    sr_message: >-
+      begin system_role:sudo ansible_version={{ ansible_version.full }}
+      {{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}
+
 - name: Determine if system is ostree and set flag
   when: not __sudo_is_ostree is defined
   block:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -3,6 +3,16 @@
 - name: Ensure that the role runs with default parameters
   hosts: all
   tasks:
+    - name: See if /dev/log exists for the fingerprint check
+      ansible.builtin.stat:
+        path: /dev/log
+      register: __register_dev_log
+
+    - name: Set the start time for the journal search
+      ansible.builtin.set_fact:
+        __journal_start_time: "{{ ansible_facts['date_time']['date'] ~ ' ' ~ ansible_facts['date_time']['time'] }}"
+      when: __register_dev_log.stat.exists
+
     - name: Run tests
       block:
         - name: Test setup
@@ -14,6 +24,23 @@
           vars:
             sudo_check_if_configured: false
           when: not __bootc_validation | d(false)
+
+        # look for the exact module invocation, not some other message that might contain the string
+        - name: Check system journal contains role fingerprints
+          ansible.builtin.shell:
+            executable: /bin/bash
+            cmd: >-
+              set -eo pipefail;
+              journalctl --since "{{ __journal_start_time }}" --no-pager |
+              grep -v " Invoked with" | grep "sr_fingerprint.*begin system_role:sudo" ||
+              { echo ERROR: BEGIN fingerprint not found; exit 1; };
+              journalctl --since "{{ __journal_start_time }}" --no-pager |
+              grep -v " Invoked with" | grep "sr_fingerprint.*success system_role:sudo" ||
+              { echo ERROR: SUCCESS fingerprint not found; exit 1; }
+          changed_when: false
+          when:
+            - __register_dev_log.stat.exists
+            - not __bootc_validation | d(false)
 
         - name: Create QEMU deployment during bootc end-to-end test
           delegate_to: localhost


### PR DESCRIPTION
Feature: Add a fingerprint string to the system log to indicate when the role began
successfully, and when the role finished successfully.  The fingerprint string indicates
the role name, a timestamp, and the platform.

Reason: Users can see when the role was used and if it was used successfully.  This
information from the system log can be collected by log scanners and aggregators
for further analysis.

Result: The role logs fingerprints to the system log.

This also adds a test to check if the fingerprints were written upon a successful
role invocation.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Introduce role fingerprint logging via a new Ansible module and validate its presence in system logs during test runs.

New Features:
- Add an sr_fingerprint Ansible module to write structured fingerprint messages to syslog with timestamps.
- Record begin and success fingerprint messages for the sudo system role, including Ansible version and platform metadata.

Enhancements:
- Update the default test playbook to capture a start time and verify that role fingerprint messages appear in the system journal when syslog is available.
- Add Ansible sanity ignore marker files for multiple supported Ansible versions.

Documentation:
- Remove existing top-level README, role-specific READMEs, changelog, and contributing guide documentation files.