### PR TITLE
fix: support continuation lines in scan_sudoers

### DIFF
--- a/library/scan_sudoers.py
+++ b/library/scan_sudoers.py
@@ -222,6 +222,13 @@ def get_config_lines(path, params):
         sudoer_file["include_directories"] = includes["include_directories"]
     except KeyError:  # ignore keyerror
         pass
+    # process continuation lines - from the man page for sudoers:
+    #       Long lines can be continued with a backslash (\) as the last
+    #       character on the line.
+    # replace backslash followed by a newline with an empty string, but only if the backslash
+    # is not escaped (preceded by a backslash)
+    # I guess someone might have a legitimate use case for ending a line with a backslash . . .
+    all_lines = re.sub(r"(?<!\\)\\\n", "", all_lines)
     # Work on each line of sudoers file
     for sline in all_lines.strip().split("\n"):
         line = sline.replace("\n", "").replace(

--- a/tests/tests_scan_sudoers.yml
+++ b/tests/tests_scan_sudoers.yml
@@ -36,6 +36,20 @@
     alias_names: "{{ alias_keys | zip(alias_keys) | flatten | list }}"
     alias_vals: "{{ alias_values.values() | flatten | list }}"
     names_vals: "{{ alias_names | zip(alias_vals) | list }}"
+    # This is the format that the role expects the aliases to be in
+    # mostly have to lowercase the keys to match the format of the role
+    aliases_in_role_input_format: "{{ dict(keys | zip(vals)) }}"
+    keys: "{{ alias_values | dict2items | map(attribute='key') | map('lower') | list }}"
+    vals: "{{ alias_values | dict2items | map(attribute='value') | list }}"
+    # This is what we expect to be the output of scan_sudoers after parsing
+    # the file with the continuation lines
+    __expected_scan_sudoers_parsed_continations:
+      all_scanned_files:
+        - /etc/sudoers
+      sudoers_files:
+        - aliases: "{{ aliases_in_role_input_format }}"
+          path: /etc/sudoers
+          user_specifications: []
   tasks:
     - name: Run tests
       block:
@@ -49,7 +63,9 @@
               {% for alias in names_vals %}
               {%   set itemvals = alias.1.values() | list %}
               {%   set space = ("NO_SPACES" in itemvals.0) | ternary("", " ") %}
-              {{ alias.0 }} {{ itemvals.0 }}{{ space }}={{ space }}{{ itemvals.1 | join("") }}
+              {{ alias.0 }} \
+              {{ itemvals.0 }}{{ space }}={{ space }}\
+              {{ itemvals.1 | join("") }}
               {% endfor %}
             mode: preserve
 
@@ -60,10 +76,11 @@
             sudo_remove_unauthorized_included_files: true
             sudo_sudoers_files:
               - path: /etc/sudoers
-                aliases: "{{ aliases }}"
-            aliases: "{{ dict(keys | zip(vals)) }}"
-            keys: "{{ alias_values | dict2items | map(attribute='key') | map('lower') | list }}"
-            vals: "{{ alias_values | dict2items | map(attribute='value') | list }}"
+                aliases: "{{ aliases_in_role_input_format }}"
+
+        - name: Assert that scan_sudoers parsed the sudoers file correctly with continuation lines
+          assert:
+            that: __expected_scan_sudoers_parsed_continations == ansible_facts.sudoers
 
         - name: Get sudoers
           slurp:


### PR DESCRIPTION
Cause: The scan_sudoers parser did not handle continuation lines in /etc/sudoers

Consequence: The /etc/sudoers file was not parsed correctly, and the role would
think it needed to change /etc/sudoers, and so was not idempotent.

Fix: scan_sudoers is fixed to correctly process continuation lines.

Result: The role is idempotent if the existing /etc/sudoers file uses
continuation lines.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sudoers parsing now resolves line continuations, improving handling of multi-line directives and aliases for more accurate interpretation.

* **Tests**
  * Added tests validating sudoers parsing with multi-line aliases and continuation syntax to ensure scan results remain correct across varied sudoers formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/sudo/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->