### PR TITLE
fix: use correct spacing before tags

### DIFF
--- a/templates/sudoers.j2
+++ b/templates/sudoers.j2
@@ -76,8 +76,8 @@ Defaults    {{ default }}
 {%- if spec.solaris_limitprivs is defined and spec.solaris_limitprivs | length > 0 %}
  LIMITPRIVS={{ spec.solaris_limitprivs | join(",") }}
 {%- endif -%}
-{%- if spec.tags is defined and spec.tags | length > 0 -%}
-{{ spec.tags | join(":") }}:
+{%- if spec.tags is defined and spec.tags | length > 0 %}
+ {{ spec.tags | join(":") }}:
 {%- endif -%}
 {{ " " + spec.commands | join(", ") }}
 {%     endif %}

--- a/tests/files/tests_selinux_tags_cloud_init.ok
+++ b/tests/files/tests_selinux_tags_cloud_init.ok
@@ -1,0 +1,7 @@
+#
+# Ansible managed
+#
+# system_role:sudo
+
+# User specifications
+maintuser ALL=(ALL) TYPE=unconfined_t ROLE=unconfined_r NOPASSWD: ALL

--- a/tests/tests_selinux_tags.yml
+++ b/tests/tests_selinux_tags.yml
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Test SELinux TYPE/ROLE with tags in user specifications
+  hosts: all
+  tasks:
+    - name: Run tests
+      block:
+        - name: Test setup
+          include_tasks: tasks/setup.yml
+
+        - name: Run the role
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            sudo_rewrite_default_sudoers_file: true
+            sudo_remove_unauthorized_included_files: true
+            sudo_sudoers_files:
+              - path: /etc/sudoers
+                defaults:
+                  - "!visiblepw"
+                  - always_set_home
+                  - match_group_by_gid
+                  - always_query_group_plugin
+                  - env_reset
+                  - secure_path:
+                      - /sbin
+                      - /bin
+                      - /usr/sbin
+                      - /usr/bin
+                  - env_keep:
+                      - COLORS
+                      - DISPLAY
+                      - HOSTNAME
+                      - HISTSIZE
+                      - KDEDIR
+                      - LS_COLORS
+                      - MAIL
+                      - PS1
+                      - PS2
+                      - QTDIR
+                      - USERNAME
+                      - LANG
+                      - LC_ADDRESS
+                      - LC_CTYPE
+                      - LC_COLLATE
+                      - LC_IDENTIFICATION
+                      - LC_MEASUREMENT
+                      - LC_MESSAGES
+                      - LC_MONETARY
+                      - LC_NAME
+                      - LC_NUMERIC
+                      - LC_PAPER
+                      - LC_TELEPHONE
+                      - LC_TIME
+                      - LC_ALL
+                      - LANGUAGE
+                      - LINGUAS
+                      - _XKB_CHARSET
+                      - XAUTHORITY
+                user_specifications:
+                  - users:
+                      - root
+                    hosts:
+                      - ALL
+                    operators:
+                      - ALL
+                    commands:
+                      - ALL
+                include_directories:
+                  - /etc/sudoers.d
+              - path: /etc/sudoers.d/90-cloud-init-users
+                user_specifications:
+                  - users:
+                      - maintuser
+                    hosts:
+                      - ALL
+                    operators:
+                      - ALL
+                    selinux_type:
+                      - unconfined_t
+                    selinux_role:
+                      - unconfined_r
+                    tags:
+                      - NOPASSWD
+                    commands:
+                      - ALL
+
+        - name: Check cloud-init users sudoers include
+          include_tasks: tasks/assert_files_identical.yml
+          vars:
+            __sudo_ok_path: files/tests_selinux_tags_cloud_init.ok
+            __sudo_test_path: /etc/sudoers.d/90-cloud-init-users
+
+      always:
+        - name: Test cleanup
+          include_tasks: tasks/cleanup.yml


### PR DESCRIPTION
Cause: The space before user spec tags was handled incorrectly.

Consequence: If you specified selinux_type and selinux_role, there was no
space before the tag, and sudo would issue an error trying to parse the
generated file.

Fix: Ensure the generated sudoers uses correct spacing before the tags.

Result: Users can specify selinux_type and selinux_role and have a correctly
formatted sudoers.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated sudoers template formatting to improve output whitespace handling.

* **Tests**
  * Added test coverage for SELinux type and role configurations in sudoers management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linux-system-roles/sudo/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->